### PR TITLE
Add Sentence Transformers to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "openai",
   "Jinja2",
   "openai-whisper",  # FIXME https://github.com/deepset-ai/haystack/issues/5731
+  "sentence-transformers>=2.2.0",  # FIXME should be an optional dependency listed in a specific subgroup
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Sentence Transformers is needed to use the first Embedders in the preview package.

In the future, this should be an optional dependency listed in a specific subgroup.