### PR TITLE
Do not install optional deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,6 @@ dependencies = [
   "lazy-imports",
   "openai",
   "Jinja2",
-  "openai-whisper",  # FIXME https://github.com/deepset-ai/haystack/issues/5731
-  "sentence-transformers>=2.2.0",  # FIXME should be an optional dependency listed in a specific subgroup
-  "pypdf", # FIXME should be an optional dependency listed in a specific subgroup
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Right now `haystack-ai` includes some optional dependencies as mandatory.

 - `openai-whisper`
 - `sentence-transformers>=2.2.0`
 - `pypdf`

This PR removes them.