### PR TITLE
Add posthog to pyproect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "lazy-imports",
   "openai",
   "Jinja2",
+  "posthog",  # telemetry
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Now that the telemetry is in place,
we should add `posthog` to the dependencies...

Otherwise, after installing this preview package with `pip install haystack-ai`,
everything fails with `ModuleNotFoundError: No module named 'posthog'`