### PR TITLE
Add `more-itertools` to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "Jinja2",
   "posthog",  # telemetry
   "pyyaml",
+  "more-itertools",  # TextDocumentSplitter
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
`more-itertools` is a lightweight dependency needed by `TextDocumentSplitter`.

In most environments (e.g. Colab), it is already installed by other libraries,  so it is difficult to notice its absence.